### PR TITLE
Fixing filters format (buyAPI)

### DIFF
--- a/src/buy-api.js
+++ b/src/buy-api.js
@@ -50,7 +50,7 @@ const searchItems = function (searchConfig) {
     queryParam = queryParam + (searchConfig.categoryId ? "&category_ids=" + searchConfig.categoryId : '');
     queryParam = queryParam + (searchConfig.limit ? "&limit=" + searchConfig.limit : "");
     if (searchConfig.fieldgroups != undefined) queryParam = queryParam + "&fieldgroups=" + searchConfig.fieldgroups.toString();
-    if (searchConfig.filter != undefined) queryParam = queryParam + "&filter=" + JSON.stringify(searchConfig.filter).replace(/[{}]/g, "");
+    if (searchConfig.filter != undefined) queryParam = queryParam + "&filter=" + JSON.stringify(searchConfig.filter).replace(/[{}]/g, "").replace(/[""]/g, "");
     console.log(queryParam);
     return new Promise((resolve, reject) => {
         makeRequest('api.ebay.com', `/buy/browse/v1/item_summary/search?${queryParam}`, 'GET', this.options.body, auth).then((result) => {


### PR DESCRIPTION
I was trying the module with your examples, but I found that when you add "filter" to a searchItems() (example: **filter: { conditions: "NEW" }** ) the filter is added to the query url including the quotation marks and the app crash because of this. I added a replace (just like the one there is for the brackets) to fix that.
