### PR TITLE
Change Filters to String for buy-api search / add sorting / add gtin search

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Ebay API Client for node js.
 The intent is to simplify the request process by handling the tedious logic. It's a thin wrapper around eBay Api.
 
 [![npm version](https://badge.fury.io/js/ebay-node-api.svg)](https://badge.fury.io/js/ebay-node-api)
-[![Build Status](https://travis-ci.org/ajay2507/ebay-node-api.svg?branch=master)](https://travis-ci.org/ajay2507/ebay-node-api) 
+[![Build Status](https://travis-ci.org/ajay2507/ebay-node-api.svg?branch=master)](https://travis-ci.org/ajay2507/ebay-node-api)
 
 
 ## Table of Contents
@@ -47,7 +47,7 @@ npm install ebay-node-api
 let eBay = require('ebay-node-api')
 
 let ebay = new eBay({
-    clientID: "-- Client APP ID ----", 
+    clientID: "-- Client APP ID ----",
     // options  - optional HTTP request timeout to apply to all requests.
 })
 ```
@@ -55,7 +55,7 @@ Creates a new `Ebay` instance.
 
 ### Getting Client ID:
 
-Join eBay developers program. 
+Join eBay developers program.
 Register your app here https://go.developer.ebay.com/quick-start-guide.
 
 #### Options
@@ -193,7 +193,8 @@ ebay.getAccessToken()
         ebay.searchItems({
             keyword: "drone",
             limit: 3,
-            filter: { maxDeliveryCost: 0 }
+            // filter: { maxDeliveryCost: 0 } old object based filter method
+		  filter: 'maxDeliveryCost:0' // new string based filter method. Format here: https://developer.ebay.com/api-docs/buy/static/ref-buy-browse-filters.html#conditionIds
         }).then((data) => {
             console.log(data);
             // Data is in format of JSON
@@ -209,7 +210,8 @@ ebay.getAccessToken()
         ebay.searchItems({
             keyword: "iphone",
             limit: 3,
-            filter: { price: "[300..800]", priceCurrency: "USD", conditions: "NEW" }
+            // filter: { price: "[300..800]", priceCurrency: "USD", conditions: "NEW" } old object based filter method
+		  filter: 'price:[300..800],priceCurrency:USD,conditions{NEW}' // new string based filter method. Format here: https://developer.ebay.com/api-docs/buy/static/ref-buy-browse-filters.html#conditionIds
         }).then((data) => {
             console.log(data);
             // Data is in format of JSON
@@ -265,5 +267,5 @@ Willing to share your idea or ready to contribute, check [here](https://github.c
 MIT.
 
 ## Examples:
-I have mentioned the examples here 
+I have mentioned the examples here
 https://github.com/ajay2507/ebay-node-api/tree/master/demo.

--- a/src/buy-api.js
+++ b/src/buy-api.js
@@ -43,10 +43,11 @@ const getItemByItemGroup = function (itemGroupId) {
 
 const searchItems = function (searchConfig) {
     if (!searchConfig) throw new Error("Error --> Missing or invalid input parameter to search");
-    if (!searchConfig.keyword && !searchConfig.categoryId) throw new Error("Error --> Keyword or category id is required in query param");
+    if (!searchConfig.keyword && !searchConfig.categoryId && !searchConfig.gtin) throw new Error("Error --> Keyword or category id is required in query param");
     if (!this.options.access_token) throw new Error("Error -->Missing Access token, Generate access token");
     const auth = "Bearer " + this.options.access_token;
     let queryParam = searchConfig.keyword ? "q=" + searchConfig.keyword : "";
+    queryParam = queryParam + (searchConfig.gtin ? "&gtin=" + searchConfig.gtin : '');
     queryParam = queryParam + (searchConfig.categoryId ? "&category_ids=" + searchConfig.categoryId : '');
     queryParam = queryParam + (searchConfig.limit ? "&limit=" + searchConfig.limit : "");
     queryParam = queryParam + (searchConfig.sort ? "&sort=" + searchConfig.sort : "");

--- a/src/buy-api.js
+++ b/src/buy-api.js
@@ -51,7 +51,7 @@ const searchItems = function (searchConfig) {
     queryParam = queryParam + (searchConfig.limit ? "&limit=" + searchConfig.limit : "");
     if (searchConfig.fieldgroups != undefined) queryParam = queryParam + "&fieldgroups=" + searchConfig.fieldgroups.toString();
     if (searchConfig.filter != undefined) queryParam = queryParam + "&filter=" + encodeURIComponent(searchConfig.filter);
-    console.log(queryParam);
+    // console.log(queryParam);
     return new Promise((resolve, reject) => {
         makeRequest('api.ebay.com', `/buy/browse/v1/item_summary/search?${queryParam}`, 'GET', this.options.body, auth).then((result) => {
             resolve(result);

--- a/src/buy-api.js
+++ b/src/buy-api.js
@@ -49,6 +49,7 @@ const searchItems = function (searchConfig) {
     let queryParam = searchConfig.keyword ? "q=" + searchConfig.keyword : "";
     queryParam = queryParam + (searchConfig.categoryId ? "&category_ids=" + searchConfig.categoryId : '');
     queryParam = queryParam + (searchConfig.limit ? "&limit=" + searchConfig.limit : "");
+    queryParam = queryParam + (searchConfig.sort ? "&sort=" + searchConfig.sort : "");
     if (searchConfig.fieldgroups != undefined) queryParam = queryParam + "&fieldgroups=" + searchConfig.fieldgroups.toString();
     if (searchConfig.filter != undefined) queryParam = queryParam + "&filter=" + encodeURIComponent(searchConfig.filter);
     // console.log(queryParam);

--- a/src/buy-api.js
+++ b/src/buy-api.js
@@ -50,7 +50,7 @@ const searchItems = function (searchConfig) {
     queryParam = queryParam + (searchConfig.categoryId ? "&category_ids=" + searchConfig.categoryId : '');
     queryParam = queryParam + (searchConfig.limit ? "&limit=" + searchConfig.limit : "");
     if (searchConfig.fieldgroups != undefined) queryParam = queryParam + "&fieldgroups=" + searchConfig.fieldgroups.toString();
-    if (searchConfig.filter != undefined) queryParam = queryParam + "&filter=" + JSON.stringify(searchConfig.filter).replace(/[{}]/g, "").replace(/[""]/g, "");
+    if (searchConfig.filter != undefined) queryParam = queryParam + "&filter=" + encodeURIComponent(searchConfig.filter);
     console.log(queryParam);
     return new Promise((resolve, reject) => {
         makeRequest('api.ebay.com', `/buy/browse/v1/item_summary/search?${queryParam}`, 'GET', this.options.body, auth).then((result) => {

--- a/src/request.js
+++ b/src/request.js
@@ -21,7 +21,7 @@ let getRequest = function getRequest(url) {
 
 let makeRequest = function postRequest(hostName, endpoint, methodName, data, token) {
     methodName == "POST" ? dataString = qs.stringify(data) : '';
-    console.log(endpoint);
+    // console.log(endpoint);
     const options = {
         "hostname": hostName,
         "path": endpoint,


### PR DESCRIPTION
## Goal of the pull request:
* [ ] Documentation
* [x ] Bugfix
* [x ] Feature (New!)
* [ ] Enhancement


## Description
Changed the buy-api filter method to remove the object based filter entry and just make it a simple string that can be formatted as ebay expects. Added commenting to the code as to where to find the correct formatting.

Added examples of how to enter as a string

Added the ability to search by gain and promoted it to same level as Keyword and Category

Added the ability to sort results